### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol server that provides browser automation capabilities using Puppeteer. This server enables LLMs to interact with web pages, take screenshots, and execute JavaScript in a real browser environment.
 
+<a href="https://glama.ai/mcp/servers/anvpl8ffa6"><img width="380" height="200" src="https://glama.ai/mcp/servers/anvpl8ffa6/badge" alt="Puppeteer Server MCP server" /></a>
+
 ## Components
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [Puppeteer MCP Server](https://glama.ai/mcp/servers/anvpl8ffa6) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/anvpl8ffa6"><img width="380" height="200" src="https://glama.ai/mcp/servers/anvpl8ffa6/badge" alt="Puppeteer Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.